### PR TITLE
Fix JFET/MOSFET pin order for non-default numbering (v1.2.21)

### DIFF
--- a/plugins/breadboard/canvas.py
+++ b/plugins/breadboard/canvas.py
@@ -63,10 +63,12 @@ _TO92_BASE_TYPES = frozenset({'NPN', 'PNP', 'JFET_N', 'JFET_P', 'BS170', 'NMOS',
 
 def _is_to92_type(type_id: str) -> bool:
     """True for TO-92-style 3-pin parts, including per-symbol pin-order
-    variants dynamically registered by guess_type_id's _bjt_type_id (e.g.
-    'PNP_ECB' for a part whose schematic pin numbering isn't C-B-E) — those
-    still render as the same TO-92 body as their 'NPN'/'PNP' base."""
-    return type_id in _TO92_BASE_TYPES or type_id.startswith(('NPN_', 'PNP_'))
+    variants dynamically registered by guess_type_id's _pin_order_type_id
+    (e.g. 'PNP_ECB' for a BJT, or 'JFET_N_DGS' for a JFET whose schematic
+    pin numbering doesn't match the base ComponentDef's assumed order) —
+    those still render as the same TO-92 body as their base type."""
+    return type_id in _TO92_BASE_TYPES or type_id.startswith(
+        ('NPN_', 'PNP_', 'JFET_N_', 'JFET_P_', 'NMOS_', 'PMOS_'))
 
 
 def _parse_svg_size(path: str):

--- a/plugins/breadboard/model/components.py
+++ b/plugins/breadboard/model/components.py
@@ -803,9 +803,16 @@ for _n in [4, 6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 40]:
     _d = _make_dip(_n)
     ALL_DEFS[_d.type_id] = _d
 
-# Physical left-to-right pin order NPN_BJT/PNP_BJT's pin_offsets assume
-# (see the "TO-92 transistors" comment above): C-B-E.
-_BJT_CANONICAL_ORDER = ('C', 'B', 'E')
+# Physical left-to-right pin order each base ComponentDef's pin_offsets assume
+# (see the "TO-92 transistors" comment above and each def's own comment).
+_PIN_ORDER_CANONICAL: Dict[str, Tuple[str, str, str]] = {
+    'NPN': ('C', 'B', 'E'),
+    'PNP': ('C', 'B', 'E'),
+    'JFET_N': ('S', 'G', 'D'),
+    'JFET_P': ('S', 'G', 'D'),
+    'NMOS': ('G', 'S', 'D'),
+    'PMOS': ('G', 'S', 'D'),
+}
 
 
 def _parse_sim_pins(raw: str) -> Dict[int, str]:
@@ -820,20 +827,26 @@ def _parse_sim_pins(raw: str) -> Dict[int, str]:
     return result
 
 
-def _bjt_type_id(base_type: str, sim_pins: str) -> str:
-    """Resolve the NPN/PNP type_id for a specific symbol, correcting for pin
-    order when its Sim.Pins field says its schematic pin numbering isn't the
-    C-B-E order NPN_BJT/PNP_BJT assume. KiCad's Transistor_BJT library names
-    its generic base symbols with the order baked into the suffix (Q_NPN_BCE,
-    Q_PNP_ECB, Q_NPN_Darlington_EBC, …), and every specific part (BD140,
-    TIP31, 2N3906, …) inherits that base's numbering — so without this,
-    parts built on a non-CBE base would land in the right ComponentDef but
-    with pins wired to the wrong physical hole."""
+def _pin_order_type_id(base_type: str, sim_pins: str) -> str:
+    """Resolve the type_id for a specific 3-pin transistor-family symbol,
+    correcting for pin order when its Sim.Pins field says its schematic pin
+    numbering isn't what the base ComponentDef assumes (see
+    _PIN_ORDER_CANONICAL). Two independent real-world sources cause this:
+    KiCad's Transistor_BJT library bakes the order into each generic base
+    symbol's name (Q_NPN_BCE, Q_PNP_ECB, …), inherited by every specific part
+    (BD140, TIP31, …); and Simulation_SPICE symbols (NJFET, PJFET, …) declare
+    their own numbering directly via Sim.Pins regardless of symbol name
+    (e.g. NJFET is "1=D 2=G 3=S", not JFET_N's assumed S-G-D). Without this,
+    such parts land in the right ComponentDef but with pins wired to the
+    wrong physical hole."""
+    canonical = _PIN_ORDER_CANONICAL.get(base_type)
+    if canonical is None:
+        return base_type
     mapping = _parse_sim_pins(sim_pins)
-    if set(mapping.keys()) != {1, 2, 3} or set(mapping.values()) != set(_BJT_CANONICAL_ORDER):
+    if set(mapping.keys()) != {1, 2, 3} or set(mapping.values()) != set(canonical):
         return base_type
     order = tuple(mapping[i] for i in (1, 2, 3))
-    if order == _BJT_CANONICAL_ORDER:
+    if order == canonical:
         return base_type
     type_id = f'{base_type}_{"".join(order)}'
     if type_id not in ALL_DEFS:
@@ -842,7 +855,7 @@ def _bjt_type_id(base_type: str, sim_pins: str) -> str:
             type_id=type_id,
             display_name=f'{base_def.display_name} ({"".join(order)})',
             ref_prefix='Q',
-            pin_offsets={pin: PinOffset(_BJT_CANONICAL_ORDER.index(func))
+            pin_offsets={pin: PinOffset(canonical.index(func))
                          for pin, func in mapping.items()},
             pin_names=mapping,
             color=base_def.color,
@@ -914,25 +927,25 @@ def guess_type_id(ref: str, value: str, symbol: str, lib: str = '',
 
     # Transistor types from symbol library name
     if 'NPN' in s:
-        return _bjt_type_id('NPN', sim_pins)
+        return _pin_order_type_id('NPN', sim_pins)
     if 'PNP' in s:
-        return _bjt_type_id('PNP', sim_pins)
+        return _pin_order_type_id('PNP', sim_pins)
     if 'PJFE' in s or ('JFET' in s and 'P' in s):
-        return 'JFET_P'
+        return _pin_order_type_id('JFET_P', sim_pins)
     if 'JFET' in s or 'NJFE' in s:
-        return 'JFET_N'
+        return _pin_order_type_id('JFET_N', sim_pins)
     if 'PMOS' in s or ('MOSFET' in s and 'P' in s):
-        return 'PMOS'
+        return _pin_order_type_id('PMOS', sim_pins)
     if 'NMOS' in s or 'MOSFET' in s:
-        return 'NMOS'
+        return _pin_order_type_id('NMOS', sim_pins)
 
     # Sim.Device field — real Transistor_BJT library parts (BD140, TIP31,
     # 2N3906, …) inherit this from their generic base symbol regardless of
     # whether their own description text spells out the polarity.
     if sim_device == 'NPN':
-        return _bjt_type_id('NPN', sim_pins)
+        return _pin_order_type_id('NPN', sim_pins)
     if sim_device == 'PNP':
-        return _bjt_type_id('PNP', sim_pins)
+        return _pin_order_type_id('PNP', sim_pins)
 
     # Switch symbols — must precede prefix fallback (SW_ prefix would default to SPST)
     if 'SW_PUSH' in s or 'PUSHBUTTON' in s or 'TACTILE' in s or 'TACT' in s:
@@ -997,12 +1010,12 @@ def guess_type_id(ref: str, value: str, symbol: str, lib: str = '',
     # Description-based fallback: works for Transistor_BJT / Transistor_FET library
     # parts whose symbol name is the part number (2N2219, BC807, 2N7002, AO3401A…).
     if 'NPN' in d and 'TRANSISTOR' in d:
-        return _bjt_type_id('NPN', sim_pins)
+        return _pin_order_type_id('NPN', sim_pins)
     if 'PNP' in d and 'TRANSISTOR' in d:
-        return _bjt_type_id('PNP', sim_pins)
+        return _pin_order_type_id('PNP', sim_pins)
     if 'P-CHANNEL' in d and 'MOSFET' in d:
-        return 'PMOS'
+        return _pin_order_type_id('PMOS', sim_pins)
     if ('N-CHANNEL' in d or 'N-CH' in d) and 'MOSFET' in d:
-        return 'NMOS'
+        return _pin_order_type_id('NMOS', sim_pins)
 
     return None

--- a/plugins/breadboard/model/simulation.py
+++ b/plugins/breadboard/model/simulation.py
@@ -404,21 +404,50 @@ def _external_model_conflicts(board: 'Breadboard', netlist: 'Netlist') -> List[s
     return conflicts
 
 
-def _bjt_element_line(ref: str, type_id: str, p, model_name: str) -> Optional[str]:
-    """SPICE Q-element for an NPN/PNP part, looking up which schematic pin
-    number is C/B/E from the ComponentDef's pin_names rather than assuming
-    1=C/2=B/3=E — needed for parts whose symbol numbers pins in a different
-    order (e.g. BD140's Q_PNP_ECB base numbers them 1=E/2=C/3=B), which
-    guess_type_id's _bjt_type_id registers as a distinct type_id ('PNP_ECB')
-    with pin_names corrected to match."""
+def _pin_nums_for(type_id: str, *funcs: str) -> Optional[Tuple[int, ...]]:
+    """Look up which schematic pin number carries each named function (e.g.
+    'C'/'B'/'E' or 'D'/'G'/'S') from the ComponentDef's pin_names, instead of
+    assuming fixed positions — needed for parts whose symbol numbers pins in
+    a different order than the base ComponentDef assumes (e.g. BD140's
+    Q_PNP_ECB base numbers them 1=E/2=C/3=B, or a Simulation_SPICE NJFET
+    declaring "1=D 2=G 3=S" directly), which guess_type_id's
+    _pin_order_type_id registers as a distinct type_id ('PNP_ECB',
+    'JFET_N_DGS', …) with pin_names corrected to match."""
     comp_def = ALL_DEFS.get(type_id)
     if comp_def is None:
         return None
     pin_of = {name: num for num, name in comp_def.pin_names.items()}
-    c, b, e = pin_of.get('C'), pin_of.get('B'), pin_of.get('E')
-    if c is None or b is None or e is None:
+    try:
+        return tuple(pin_of[f] for f in funcs)
+    except KeyError:
         return None
+
+
+def _bjt_element_line(ref: str, type_id: str, p, model_name: str) -> Optional[str]:
+    """SPICE Q-element: Q<ref> <collector> <base> <emitter> <model>."""
+    nums = _pin_nums_for(type_id, 'C', 'B', 'E')
+    if nums is None:
+        return None
+    c, b, e = nums
     return f'Q{ref}  {p(c)}  {p(b)}  {p(e)}  {model_name}'
+
+
+def _jfet_element_line(ref: str, type_id: str, p, model_name: str) -> Optional[str]:
+    """SPICE J-element: J<ref> <drain> <gate> <source> <model>."""
+    nums = _pin_nums_for(type_id, 'D', 'G', 'S')
+    if nums is None:
+        return None
+    d, g, s = nums
+    return f'J{ref}  {p(d)}  {p(g)}  {p(s)}  {model_name}'
+
+
+def _mosfet_element_line(ref: str, type_id: str, p, model_name: str) -> Optional[str]:
+    """SPICE M-element: M<ref> <drain> <gate> <source> <bulk> <model>."""
+    nums = _pin_nums_for(type_id, 'D', 'G', 'S')
+    if nums is None:
+        return None
+    d, g, s = nums
+    return f'M{ref}  {p(d)}  {p(g)}  {p(s)}  0  {model_name}'
 
 
 def _element_line(ref: str, type_id: str,
@@ -460,19 +489,17 @@ def _element_line(ref: str, type_id: str,
     if tid == 'PNP' or tid.startswith('PNP_'):
         return _bjt_element_line(ref, tid, p, 'QPNP')
 
-    if tid == 'JFET_N':
-        # pin1=S, pin2=G, pin3=D  →  SPICE J: drain gate source model
-        return f'J{ref}  {p(3)}  {p(2)}  {p(1)}  JFET_N'
+    if tid == 'JFET_N' or tid.startswith('JFET_N_'):
+        return _jfet_element_line(ref, tid, p, 'JFET_N')
 
-    if tid == 'JFET_P':
-        return f'J{ref}  {p(3)}  {p(2)}  {p(1)}  JFET_P'
+    if tid == 'JFET_P' or tid.startswith('JFET_P_'):
+        return _jfet_element_line(ref, tid, p, 'JFET_P')
 
-    if tid in ('NMOS', 'BS170'):
-        # pin1=G, pin2=S, pin3=D  →  SPICE M: drain gate source bulk model
-        return f'M{ref}  {p(3)}  {p(1)}  {p(2)}  0  NMOS'
+    if tid in ('NMOS', 'BS170') or tid.startswith('NMOS_'):
+        return _mosfet_element_line(ref, tid, p, 'NMOS')
 
-    if tid == 'PMOS':
-        return f'M{ref}  {p(3)}  {p(1)}  {p(2)}  0  PMOS'
+    if tid == 'PMOS' or tid.startswith('PMOS_'):
+        return _mosfet_element_line(ref, tid, p, 'PMOS')
 
     if tid == 'POT':
         # Model as two equal resistors at 50% wiper position

--- a/plugins/breadboard/window.py
+++ b/plugins/breadboard/window.py
@@ -41,7 +41,7 @@ from .model import (
     TERMINAL_NAMES,
 )
 
-PLUGIN_VERSION = '1.2.20'
+PLUGIN_VERSION = '1.2.21'
 REPO           = 'kerstensrobin/kicad-breadboard'
 
 # Toolbar button IDs


### PR DESCRIPTION
## Summary
- Generalizes the BD140 pin-order fix (v1.2.19) to JFETs and MOSFETs: symbols whose `Sim.Pins` field disagrees with the assumed S-G-D / G-S-D order (e.g. Simulation_SPICE NJFET/PJFET, which declare 1=D 2=G 3=S) now get a corrected pin-order variant instead of wiring pins to the wrong physical hole.
- Extends TO-92 rendering and the SPICE exporter to recognize the new variant type_ids.
- Quiet patch release, no README/highlights changes.

## Test plan
- [x] Verified against real TS808JFET netlist: NJFET now resolves to `JFET_N_DGS` with corrected pin_offsets
- [x] Verified standard (non-variant) JFET_N/NMOS/PMOS SPICE lines are unchanged
- [ ] Confirm on Robin's live board after "Update from schematic" + re-placing Q1